### PR TITLE
Remaining characters for supporting information

### DIFF
--- a/jasmin_services/templates/jasmin_services/role_apply.html
+++ b/jasmin_services/templates/jasmin_services/role_apply.html
@@ -75,4 +75,36 @@
         </div>
     </form>
 </div>
+
+<script type="text/javascript">
+    var textAreas = document.getElementsByTagName("textarea");
+    var i;
+    for (i = 0; i < textAreas.length; i++) {
+        textArea = textAreas[i];
+        if ($(textArea).attr('maxlength')) {
+            var maxLength = $(textArea).attr('maxlength');
+            var length = $(textArea).val().length;
+            var remaining = maxLength-length;
+            var textAreaID = $(textArea).attr('id');
+
+            let counter = document.createElement('span');
+            counter.id = textAreaID + '_counter';
+            counter.innerHTML = remaining;
+            $(textArea).after(counter);
+            counter.after(' characters remaining');
+        };
+    };
+
+    $('textarea').keyup(function() {
+        if ($(this).attr('maxlength')) {
+            var maxLength = $(this).attr('maxlength');
+            var length = $(this).val().length;
+            var remaining = maxLength-length;
+
+            let counter = document.getElementById(this.id + '_counter');
+            $(counter).text(remaining);
+        };
+    }); 
+</script>
+
 {% endblock %}


### PR DESCRIPTION
Adding javascript to display remaining characters for supporting information to the user.

Max length for a text area can be set on the form admin page.

![Screenshot 2021-02-09 at 14 14 48](https://user-images.githubusercontent.com/34507919/107377570-08a3b900-6ae3-11eb-9dc9-2efd5bd9f077.png)

The remaining characters are then shown to the user on the Role Apply page.

![Screenshot 2021-02-09 at 14 13 54](https://user-images.githubusercontent.com/34507919/107377706-283ae180-6ae3-11eb-8df6-0a4d9b8412dd.png)

![Screenshot 2021-02-09 at 14 31 13](https://user-images.githubusercontent.com/34507919/107378039-7fd94d00-6ae3-11eb-9bb0-d4554a21fa38.png)

Closes https://github.com/cedadev/jasmin-account/issues/122 