### PR TITLE
Fixed bug where Grants are passed to list views while still being QuerySet objects

### DIFF
--- a/jasmin_services/models/grant.py
+++ b/jasmin_services/models/grant.py
@@ -55,7 +55,7 @@ class GrantQuerySet(models.QuerySet):
             else:
                 return grants.order_by("granted_at").first()
         else:
-            return grants
+            return grants.first()
 
 
 def _default_expiry():


### PR DESCRIPTION
This results in the "you have a grant" badge in the my_services or general service list views to show as though it was valid even if your grant has been revoked.

e.g.
![image](https://github.com/user-attachments/assets/89cc8879-fb26-4af4-ba50-b418cee50dd3)
![image](https://github.com/user-attachments/assets/46d0f0c1-f450-4230-aebb-c78bd44f14c0)
