### PR TITLE
Fixed a bug similar to the Grant issue, for Requests not showing correctly

### DIFF
--- a/jasmin_services/models/request.py
+++ b/jasmin_services/models/request.py
@@ -49,7 +49,7 @@ class RequestQuerySet(models.QuerySet):
         """
         requests = self.filter(access__role=role, access__user=user)
         if requests.count() == 1:
-            return requests
+            return requests.first()
         elif requests.count() > 0:
             pending_requests = requests.filter(state=RequestState.PENDING)
             if pending_requests:
@@ -57,7 +57,7 @@ class RequestQuerySet(models.QuerySet):
             else:
                 return requests.order_by("requested_at").first()
         else:
-            return requests
+            return requests.first()
 
 
 class RequestState:


### PR DESCRIPTION
Line 60 is weird. But, also harmless. I think that ideally the filter_ methods are supposed to always return QuerySet objects. So, adding first() is breaking this rule anyway. Oh well.

This just fixes the case where the request rejected badge doesn't show in a service list in the specific case where there's precisely one request, and it's rejected.