### PR TITLE
Make internal comments visible in Grant/Request change page

### DIFF
--- a/jasmin_services/forms/__init__.py
+++ b/jasmin_services/forms/__init__.py
@@ -282,7 +282,7 @@ def admin_message_form_factory(service):
         },
     )
 
-
+# When moving this out of a custom form, we should tidy with fieldsets, e.g. hide revoked_at when revoked is False
 class AdminGrantForm(forms.ModelForm):
     class Meta:
         model = Grant
@@ -297,6 +297,7 @@ class AdminGrantForm(forms.ModelForm):
             "revoked_at",
             "user_reason",
             "internal_reason",
+            "internal_comment",
         )
         widgets = {"access": forms.HiddenInput()}
 
@@ -380,6 +381,9 @@ class AdminRequestForm(forms.ModelForm):
             "previous_grant",
             "previous_request",
             "incomplete",
+            "internal_comment",
+            "user_reason",
+            "internal_reason",
         )
         widgets = {"access": forms.HiddenInput()}
 

--- a/jasmin_services/models/grant.py
+++ b/jasmin_services/models/grant.py
@@ -134,7 +134,7 @@ class Grant(HasMetadata):
     )
 
     # Add a field for an internal comment about the grant.
-    internal_comment = models.TextField(blank=True, verbose_name="Internal nodes")
+    internal_comment = models.TextField(blank=True, verbose_name="Internal notes")
 
     @property
     def user(self):

--- a/jasmin_services/models/request.py
+++ b/jasmin_services/models/request.py
@@ -239,6 +239,7 @@ class Request(HasMetadata):
             previous_grant=self.previous_grant,
             granted_by=granted_by,
             expires=expires,
+            internal_comment=self.internal_comment,
         )
         self.copy_metadata_to(self.resulting_grant)
         self.save()

--- a/jasmin_services/models/role.py
+++ b/jasmin_services/models/role.py
@@ -85,7 +85,7 @@ class Role(models.Model):
     auto_accept = models.BooleanField(
         default=False,
         help_text="Auto accepts all requested access giving users with a 1 "
-        "year experation date ",
+        "year expiration date.",
     )
     #: Determines the order that the roles appear when listed.
     position = models.PositiveIntegerField(

--- a/jasmin_services/views/mixins.py
+++ b/jasmin_services/views/mixins.py
@@ -17,7 +17,7 @@ class WithServiceMixin:
 
     @staticmethod
     def get_service(category_name: str, service_name: str) -> models.Service:
-        """Get a service from it's category and name."""
+        """Get a service from its category and name."""
         try:
             service = models.Service.objects.get(name=service_name, category__name=category_name)
         except models.Service.DoesNotExist as err:


### PR DESCRIPTION
- Adds internal comment, user reason for incomplete, internal reason for incomplete to the custom form for the Request change page
- Adds internal comment to the custom form for the Grant change page
- Fixed some typos found in jasmin-services